### PR TITLE
Added "grit ls" alias for "grit index ls"

### DIFF
--- a/src/cmd/grit/main.go
+++ b/src/cmd/grit/main.go
@@ -90,6 +90,12 @@ func main() {
 			BashComplete: autocomplete.New(autocomplete.Slug),
 		},
 		{
+			Name:      "ls",
+			Usage:     "List slugs that begin with a prefix (alias of \"index ls\".",
+			ArgsUsage: "[<prefix>]",
+			Action:    withConfigAndIndex(indexList),
+		},
+		{
 			Name:      "mv",
 			Usage:     "Move a clone into the correct directory.",
 			ArgsUsage: "[<path>]",


### PR DESCRIPTION
Optional if you want to merge it, I would find it handy.