### PR TITLE
Add naive implementation of `browse` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next Release
 
 - **[NEW]** Added `slug` command, which prints the slug for the current clone directory
+- **[NEW]** Added `browse` command, which opens the webpage for the current repo (assumes GitHub / GHE)
+- **[IMPROVED]** Use `promptui` for interactive CLI elements
 
 ## 0.6.6 (2017-11-16)
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6ee15d125c5e97e8156596d935fdd489099b904af125684e75e9fb6e4e9c3396
-updated: 2017-12-01T12:46:06.519582295+10:00
+hash: 8f4a5b2d76a282b6f4f9924e9743b2f2b44eb61e7031c658a28d3fb8795b8981
+updated: 2017-12-04T17:03:00.79294+10:00
 imports:
 - name: github.com/boltdb/bolt
   version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
@@ -46,6 +46,10 @@ imports:
   version: 1744e2970ca51c86172c8190fadad617561ed6e7
   subpackages:
   - diffmatchpatch
+- name: github.com/skratchdot/open-golang
+  version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
+  subpackages:
+  - open
 - name: github.com/src-d/gcfg
   version: f187355171c936ac84a82793659ebb4936bc1c23
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,6 @@ import:
   version: ~0.0.3
 - package: github.com/manifoldco/promptui
   version: ~0.2.1
+- package: github.com/skratchdot/open-golang
+  subpackages:
+  - open

--- a/src/cmd/grit/browse.go
+++ b/src/cmd/grit/browse.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/jmalloc/grit/src/grit"
+	"github.com/jmalloc/grit/src/grit/index"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/urfave/cli"
+)
+
+func browse(cfg grit.Config, idx *index.Index, c *cli.Context) error {
+	dir, ok, err := dirFromSlugArg(cfg, idx, c, 0)
+	if err != nil {
+		return err
+	} else if !ok {
+		return nil
+	}
+
+	rem, ok, err := chooseRemote(cfg, c, dir, nil)
+	if err != nil {
+		return err
+	} else if !ok {
+		return nil
+	}
+
+	ep, _, err := grit.EndpointFromRemote(rem)
+	if err != nil {
+		return err
+	}
+
+	u := url.URL{
+		Scheme: "https",
+		Host:   ep.Host(),
+		Path:   strings.TrimSuffix(ep.Path(), ".git"),
+	}
+
+	write(c, "opening %s", u.String())
+
+	return open.Run(u.String())
+}

--- a/src/cmd/grit/interactive.go
+++ b/src/cmd/grit/interactive.go
@@ -85,7 +85,10 @@ func chooseRemote(
 		cfg := rem.Config()
 		ep, url, err := grit.EndpointFromRemote(cfg)
 		if err == nil {
-			info := fn(cfg, ep)
+			var info string
+			if fn != nil {
+				info = fn(cfg, ep)
+			}
 			opts = append(opts, fmt.Sprintf("[%s] %s%s", cfg.Name, url, info))
 		} else {
 			opts = append(opts, fmt.Sprintf("[%s] %s (invalid)", cfg.Name, url))

--- a/src/cmd/grit/main.go
+++ b/src/cmd/grit/main.go
@@ -139,6 +139,14 @@ func main() {
 			},
 		},
 		{
+			Name:         "browse",
+			Usage:        "Open the repository's webpage in the system's default browser.",
+			UsageText:    "This command currently assumes all sources refer to GitHub or GitHub Enterprise servers.",
+			ArgsUsage:    "[<slug>]",
+			Action:       withConfigAndIndex(browse),
+			BashComplete: autocomplete.New(autocomplete.Slug),
+		},
+		{
 			Name:      "set-url",
 			Usage:     "Set the URL for a Git remote and move the clone into the correct directory.",
 			ArgsUsage: "<slug | url> [<path>]",
@@ -322,6 +330,24 @@ func dirFromArg(c *cli.Context, n int) (string, error) {
 	}
 
 	return c.Args()[n], nil
+}
+
+// dirFromSlugArgs returns the dir for the slug in the n-th arg, if present, or
+// the current working directory.
+func dirFromSlugArg(cfg grit.Config, idx *index.Index, c *cli.Context, n int) (string, bool, error) {
+	if c.Args().Present() {
+		slug := c.Args().First()
+		dirs := idx.Find(slug)
+		if len(dirs) == 0 {
+			return "", false, notIndexed(slug)
+		}
+
+		dir, ok := chooseCloneDir(cfg, c, dirs)
+		return dir, ok, nil
+	}
+
+	dir, err := os.Getwd()
+	return dir, true, err
 }
 
 // formatDir returns dir formatted for display.


### PR DESCRIPTION
Partially addresses #56.

The implementation current assumes that all sources refer to GitHub or GitHub Enterprise installations. After working out what repo and remote you are talking about, it simply opens `https://<host>/<path-without-extension>`
