### PR TITLE
Allow specification of ordering of the base path in directory sorting.

### DIFF
--- a/src/cmd/grit/browse.go
+++ b/src/cmd/grit/browse.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/jmalloc/grit/src/grit"
 	"github.com/jmalloc/grit/src/grit/index"
+	"github.com/jmalloc/grit/src/grit/pathutil"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/urfave/cli"
 )
 
 func browse(cfg grit.Config, idx *index.Index, c *cli.Context) error {
-	dir, ok, err := dirFromSlugArg(cfg, idx, c, 0)
+	dir, ok, err := dirFromSlugArg(cfg, idx, c, 0, pathutil.PreferBase)
 	if err != nil {
 		return err
 	} else if !ok {

--- a/src/cmd/grit/cd.go
+++ b/src/cmd/grit/cd.go
@@ -3,25 +3,23 @@ package main
 import (
 	"github.com/jmalloc/grit/src/grit"
 	"github.com/jmalloc/grit/src/grit/index"
+	"github.com/jmalloc/grit/src/grit/pathutil"
 	"github.com/urfave/cli"
 )
 
 func cd(cfg grit.Config, idx *index.Index, c *cli.Context) error {
-	slug := c.Args().First()
-	if slug == "" {
+	if !c.Args().Present() {
 		return errNotEnoughArguments
 	}
 
-	dirs := idx.Find(slug)
-	if len(dirs) == 0 {
-		return notIndexed(slug)
+	dir, ok, err := dirFromSlugArg(cfg, idx, c, 0, pathutil.PreferOther)
+	if err != nil {
+		return err
+	} else if !ok {
+		return errSilentFailure
 	}
 
-	if dir, ok := chooseCloneDir(cfg, c, dirs); ok {
-		writeln(c, dir)
-		exec(c, "cd", dir)
-		return nil
-	}
-
-	return errSilentFailure
+	writeln(c, dir)
+	exec(c, "cd", dir)
+	return nil
 }

--- a/src/cmd/grit/interactive.go
+++ b/src/cmd/grit/interactive.go
@@ -3,16 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
-	"sort"
-	"strings"
 
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 
 	"github.com/jmalloc/grit/src/grit"
-	"github.com/jmalloc/grit/src/grit/pathutil"
 	"github.com/manifoldco/promptui"
 	"github.com/urfave/cli"
 )
@@ -53,30 +49,10 @@ func choose(c *cli.Context, opt []string) (int, bool) {
 }
 
 func chooseCloneDir(cfg grit.Config, c *cli.Context, dirs []string) (string, bool) {
-	cwd, _ := os.Getwd()
+	var opts []string
 
-	// compute "distance from cwd" for each dir
-	dists := make([]uint32, len(dirs))
-	for idx, dir := range dirs {
-		dists[idx] = pathutil.Distance(cwd, dir)
-	}
-
-	// sort the dirs such that dirs closest to cwd are listed first
-	// any two dirs with the same distance are further sorted by name
-	sort.Slice(dirs, func(i, j int) bool {
-		di, dj := dists[i], dists[j]
-
-		if di == dj {
-			return strings.Compare(dirs[i], dirs[j]) < 0
-		}
-
-		return di < dj
-	})
-
-	// make options list from the sorted list of dirs
-	opts := make([]string, len(dirs))
-	for idx, dir := range dirs {
-		opts[idx] = formatDir(cfg, dir)
+	for _, dir := range dirs {
+		opts = append(opts, formatDir(cfg, dir))
 	}
 
 	if i, ok := choose(c, opts); ok {

--- a/src/grit/pathutil/distance.go
+++ b/src/grit/pathutil/distance.go
@@ -3,14 +3,35 @@ package pathutil
 import (
 	"math"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
-// Distance returns the "distance" from base to target. The lower the
-// distance the "closer" target is to "base".
-func Distance(base, target string) (dist uint32) {
+// Distance is a numerical distance between two paths
+type Distance uint32
+
+const (
+	// PreferBase is the zero distance. When passed to SortByDistance(), the
+	// base path is sorted to the top.
+	PreferBase Distance = 0
+
+	// PreferChildren is a distance midway between children of base paths, and
+	// non-children. When passed to SortByDistance(), the base path is sorted
+	// below its own children, but above non-children.
+	PreferChildren Distance = math.MaxUint32 / 2
+
+	// PreferOther is the maximimum distance. When passed to SortByDistance(),
+	// the base path is sorted to the bottom.
+	PreferOther Distance = math.MaxUint32
+)
+
+// DistanceBetween returns the "distance" from base to target. The more "hops"\
+// required to move from base to target, the larger the distance. Targets that
+// are children of base are "closer" than targets that are not. If target is
+// equal to base, the distance is baseDist.
+func DistanceBetween(base, target string, baseDist Distance) (dist Distance) {
 	if base == target {
-		return 0
+		return baseDist
 	}
 
 	rel, err := filepath.Rel(base, target)
@@ -19,15 +40,47 @@ func Distance(base, target string) (dist uint32) {
 	}
 
 	// count the number of path separators to get the distance
-	dist = uint32(strings.Count(
+	dist = Distance(strings.Count(
 		rel,
 		string(filepath.Separator),
 	))
 
 	// increase the distance for targets that are not a subfolder of base
-	if strings.HasPrefix("..", rel) {
-		dist += math.MaxUint32 / 2
+	if strings.HasPrefix(rel, "..") {
+		dist += 1 + PreferChildren
 	}
 
 	return
+}
+
+// SortByDistance sorts paths according to their "distance" from base, according
+// to Distance(base, path). Any two paths with the same distance from base are
+// further sorted by their name.
+func SortByDistance(base string, paths []string, baseDist Distance) {
+	type elem struct {
+		dist Distance
+		path string
+	}
+
+	elems := make([]elem, len(paths))
+	for i, p := range paths {
+		elems[i] = elem{
+			DistanceBetween(base, p, baseDist),
+			p,
+		}
+	}
+
+	sort.Slice(elems, func(i, j int) bool {
+		ei, ej := elems[i], elems[j]
+
+		if ei.dist == ej.dist {
+			return strings.Compare(ei.path, ej.path) < 0
+		}
+
+		return ei.dist < ej.dist
+	})
+
+	for idx, elem := range elems {
+		paths[idx] = elem.path
+	}
 }


### PR DESCRIPTION
This allows different commands to order their directories in different ways.

The `cd` command assumes you are not trying to change directory into the
directory you are already in, and hence sorts such that the current directory is
always at the bottom.

The `browse` command, when passed a slug, assumes that you are more likely want
the current clone, and orders the current working directory at the top.

**TODO**: sort on the host + slug (`github.com/org/repo`) rather than the actual directory name, so that repos from the same org but in different paths (ie, one in `$GOPATH`, one not) have a closer distance.