### PR TITLE
fixes cloning an empty repo

### DIFF
--- a/cmd/grit/clone.go
+++ b/cmd/grit/clone.go
@@ -38,14 +38,14 @@ func clone(cfg grit.Config, idx *index.Index, c *cli.Context) error {
 		fmt.Fprintln(os.Stderr, "found existing clone")
 
 	case transport.ErrEmptyRemoteRepository:
-		fmt.Fprintln(os.Stderr, "cloned an empty repository")
-
 		r, err := git.PlainInit(dir, false /* isBare */)
 		if err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
 
 		if _, err := r.CreateRemote(&config.RemoteConfig{Name: git.DefaultRemoteName, URLs: []string{ep.Actual}}); err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
 
@@ -54,11 +54,11 @@ func clone(cfg grit.Config, idx *index.Index, c *cli.Context) error {
 			branchName = grit.DefaultBranchName
 		}
 		if err = r.CreateBranch(&config.Branch{Name: branchName, Remote: git.DefaultRemoteName, Merge: plumbing.Master}); err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
 
-	case nil:
-		return nil
+		fmt.Fprintln(os.Stderr, "cloned an empty repository")
 
 	default:
 		_ = os.RemoveAll(dir)

--- a/cmd/grit/clone.go
+++ b/cmd/grit/clone.go
@@ -38,14 +38,14 @@ func clone(cfg grit.Config, idx *index.Index, c *cli.Context) error {
 		fmt.Fprintln(os.Stderr, "found existing clone")
 
 	case transport.ErrEmptyRemoteRepository:
-		fmt.Fprintln(os.Stderr, "cloned an empty repository")
-
 		r, err := git.PlainInit(dir, false /* isBare */)
 		if err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
 
 		if _, err := r.CreateRemote(&config.RemoteConfig{Name: git.DefaultRemoteName, URLs: []string{ep.Actual}}); err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
 
@@ -54,8 +54,11 @@ func clone(cfg grit.Config, idx *index.Index, c *cli.Context) error {
 			branchName = grit.DefaultBranchName
 		}
 		if err = r.CreateBranch(&config.Branch{Name: branchName, Remote: git.DefaultRemoteName, Merge: plumbing.Master}); err != nil {
+			_ = os.RemoveAll(dir)
 			return err
 		}
+
+		fmt.Fprintln(os.Stderr, "cloned an empty repository")
 
 	default:
 		_ = os.RemoveAll(dir)

--- a/cmd/grit/clone.go
+++ b/cmd/grit/clone.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 
 	"github.com/jmalloc/grit"
@@ -37,6 +39,23 @@ func clone(cfg grit.Config, idx *index.Index, c *cli.Context) error {
 
 	case transport.ErrEmptyRemoteRepository:
 		fmt.Fprintln(os.Stderr, "cloned an empty repository")
+
+		r, err := git.PlainInit(dir, false /* isBare */)
+		if err != nil {
+			return err
+		}
+
+		if _, err := r.CreateRemote(&config.RemoteConfig{Name: git.DefaultRemoteName, URLs: []string{ep.Actual}}); err != nil {
+			return err
+		}
+
+		branchName := cfg.Clone.DefaultBranch
+		if branchName == "" {
+			branchName = grit.DefaultBranchName
+		}
+		if err = r.CreateBranch(&config.Branch{Name: branchName, Remote: git.DefaultRemoteName, Merge: plumbing.Master}); err != nil {
+			return err
+		}
 
 	default:
 		_ = os.RemoveAll(dir)

--- a/config.go
+++ b/config.go
@@ -10,11 +10,17 @@ import (
 	"github.com/jmalloc/grit/pathutil"
 )
 
+const (
+	// DefaultBranchName is used when cloning an empty repository for the initial setup.
+	DefaultBranchName = "master"
+)
+
 // Config holds Grit configuration.
 type Config struct {
 	Clone struct {
-		Root    string                      `toml:"root"`
-		Sources map[string]EndpointTemplate `toml:"sources"`
+		Root          string                      `toml:"root"`
+		Sources       map[string]EndpointTemplate `toml:"sources"`
+		DefaultBranch string                      `toml:"default-branch"`
 	} `toml:"clone"`
 	Index struct {
 		Paths []string `toml:"paths"`

--- a/etc/complete-example.toml
+++ b/etc/complete-example.toml
@@ -26,6 +26,12 @@
 # Will clone git@github.com:jmalloc/grit.git to ~/grit/github.com/jmalloc/grit
 root = "~/my-repos"
 
+# "default-branch" is is used when cloning an empty repo.
+
+# This is "main" on github.com, but "master" by convention elsewhere, 
+# you can override the default of "master" here.
+default-branch = "master"
+
 # "clone.sources" is a list of additional Git sources.
 #
 # The key is an arbitrary label for the source. It can be used when cloning to

--- a/etc/complete-example.toml
+++ b/etc/complete-example.toml
@@ -27,7 +27,7 @@
 root = "~/my-repos"
 
 # "default-branch" is is used when cloning an empty repo.
-
+#
 # This is "main" on github.com, but "master" by convention elsewhere, 
 # you can override the default of "master" here.
 default-branch = "master"

--- a/etc/testing.toml
+++ b/etc/testing.toml
@@ -2,8 +2,7 @@
 root = "/tmp/grit-test/clone"
 
 [clone.sources]
-# my-company = "git@github.example.com:{{slug}}.git"
-github = "file:///tmp/grit-repos/{{slug}}.git"
+my-company = "git@github.example.com:{{slug}}.git"
 
 [index]
 paths = ["/tmp/grit-test/clone"]

--- a/etc/testing.toml
+++ b/etc/testing.toml
@@ -2,7 +2,8 @@
 root = "/tmp/grit-test/clone"
 
 [clone.sources]
-my-company = "git@github.example.com:{{slug}}.git"
+# my-company = "git@github.example.com:{{slug}}.git"
+github = "file:///tmp/grit-repos/{{slug}}.git"
 
 [index]
 paths = ["/tmp/grit-test/clone"]


### PR DESCRIPTION
As per go-git/go-git#118, it's expected behaviour to just fail to clone an empty repo, this will on receiving the empty repository error, init, add remote and add branch tracking remote to the local repository.
